### PR TITLE
oppo-common: Replace variable for setup wizard complete

### DIFF
--- a/keyhandler/src/com/cyanogenmod/settings/device/KeyHandler.java
+++ b/keyhandler/src/com/cyanogenmod/settings/device/KeyHandler.java
@@ -120,8 +120,8 @@ public class KeyHandler implements DeviceKeyHandler {
     }
 
     private boolean hasSetupCompleted() {
-        return CMSettings.Secure.getInt(mContext.getContentResolver(),
-            CMSettings.Secure.CM_SETUP_WIZARD_COMPLETED, 0) != 0;
+        return Settings.Secure.getInt(mContext.getContentResolver(),
+                Settings.Secure.USER_SETUP_COMPLETE, 0) != 0;
     }
 
     public boolean handleKeyEvent(KeyEvent event) {


### PR DESCRIPTION
* With more and more gapps removing our setupwizard,
  CM_SETUP_WIZARD_COMPLETED isn't being set
* To fix this, use USER_SETUP_COMPLETE instead,
  which is set regardless of our setupwizard

Change-Id: Ic1d9619843e9c967dd3a72ca791d1e446f830f27
Signed-off-by: Paul Keith <javelinanddart@aidenswann.com>